### PR TITLE
Also ignore .dist and export/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+export/
 node_modules
 temp/
+.dist/
 .www/
 components/
 sass/


### PR DESCRIPTION
These are created by the `grunt export` command, and contains the compiled code, which we'd normally not want to check in.
