### PR TITLE
Ignore .dist and export/ on generated site.

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,6 @@
 node_modules
 components
+export/
+<% if (!ghDeploy) { %>.dist/<% } %>
 .www
 .sass-cache


### PR DESCRIPTION
See #2 for discussion.

Only ignoring `.dist` if not deploying to Github.
